### PR TITLE
The ffmpeg subprocess takes OS environment variables

### DIFF
--- a/ffmpeg.go
+++ b/ffmpeg.go
@@ -1,6 +1,7 @@
 package goradiru
 
 import (
+	"os"
 	"os/exec"
 )
 
@@ -15,7 +16,9 @@ func newFFMPEG(inputFilePath string) (*ffmpeg, error) {
 	}
 
 	/* #nosec */
-	return &ffmpeg{exec.Command(cmdPath, "-i", inputFilePath)}, nil
+	cmd := exec.Command(cmdPath, "-i", inputFilePath)
+	cmd.Env = os.Environ()
+	return &ffmpeg{cmd}, nil
 }
 
 func (f *ffmpeg) setArgs(args ...string) {


### PR DESCRIPTION
FFMpeg accepts many types of OS environment variables.
https://ffmpeg.org/ffmpeg.html
This allows all variables set in the OS instance to be captured in the sub-process.
For testing ran `main.go` with `dl` argument with and without `http_proxy` OS environment variable.